### PR TITLE
Fix for StaticProvider throws a fatal error due to unimplemented meth…

### DIFF
--- a/src/Plugin/Purl/Provider/StaticProvider.php
+++ b/src/Plugin/Purl/Provider/StaticProvider.php
@@ -22,4 +22,7 @@ class StaticProvider extends ProviderAbstract
             'cinq' => 5,
         );
     }
+  public function getModifierData() {
+    // TODO: Implement getModifierData() method.
+  }
 }


### PR DESCRIPTION
Purl throws a fatal error under Drupal 7, if the StaticProvider is included... quick fix to just add stub.