### PR TITLE
Add an option to allow plugins to detect when a link should omit the

### DIFF
--- a/src/Event/PurlNodeContextRoutes.php
+++ b/src/Event/PurlNodeContextRoutes.php
@@ -69,7 +69,8 @@ class PurlNodeContextRoutes implements EventSubscriberInterface {
         if (!isset($purl_settings['keep_context']) || !$purl_settings['keep_context']) {
           $url = \Drupal\Core\Url::fromRoute($this->routeMatch->getRouteName(), $this->routeMatch->getRawParameters()->all(), [
             'host' => Settings::get('purl_base_domain'),
-            'absolute' => TRUE
+            'absolute' => TRUE,
+            'purl_exit' => TRUE,
           ]);
           try {
             $redirect_response = new TrustedRedirectResponse($url->toString());


### PR DESCRIPTION
modifier, to avoid redirect loops

... When URLs get rewritten correctly, it rewrites all URLs on the page. For content types that have the "preserve purl context" option disabled, you get a rewrite loop. A quick fix: add an option to the URL option array, and if it's set, don't modify the URL. (The other side that consumes this is in the group_purl module -- should probably also patch the Method plugins in this module.)