### PR TITLE
Fix typo in plugin definition, to get the context for rewriting outbound

### DIFF
--- a/src/Plugin/Purl/Method/MethodAbstract.php
+++ b/src/Plugin/Purl/Method/MethodAbstract.php
@@ -18,6 +18,6 @@ abstract class MethodAbstract extends PluginBase implements MethodInterface
 
     public function getStages()
     {
-      return $this->pluginDefinition['stages'];
+      return $this->pluginDefinition['stage'];
     }
 }


### PR DESCRIPTION
Outbound rewriting of URLs fails due to the wrong property on the plugin configuration, simple typo fix.