### PR TITLE
Register Purl plugin types under plugin.manager so that drupal console

### DIFF
--- a/purl.services.yml
+++ b/purl.services.yml
@@ -5,6 +5,14 @@ services:
     calls:
       - [setContainer, [ '@service_container' ]]
 
+  plugin.manager.purl_method_manager:
+    class: Drupal\purl\Plugin\MethodPluginManager
+    parent: default_plugin_manager
+
+  plugin.manager.purl_provider_manager:
+    class: Drupal\purl\Plugin\ProviderManager
+    parent: default_plugin_manager
+
   purl.plugin.provider_manager:
     class: Drupal\purl\Plugin\ProviderManager
     parent: default_plugin_manager


### PR DESCRIPTION
can list them

... The Method and Provider purl plugin types are not properly registered, and so you can't easily generate plugin instances with drupal console, or find them in the plugin list.

I've added the appropriate entries in the services.yml file that makes them appear -- these do duplicate the other plugin manager entries, so more cleanup should probably be done here.