### PR TITLE
Cleanup

### DIFF
--- a/src/Annotation/PurlProvider.php
+++ b/src/Annotation/PurlProvider.php
@@ -5,10 +5,30 @@ namespace Drupal\purl\Annotation;
 use Drupal\Component\Annotation\Plugin;
 
 /**
+ * Defines a Scheduled message item annotation object.
+ *
+ * @see plugin_api
+ *
  * @Annotation
  */
 class PurlProvider extends Plugin
 {
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The label of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $label;
+
     public function __construct($values)
     {
         parent::__construct($values);

--- a/src/Plugin/ProviderManager.php
+++ b/src/Plugin/ProviderManager.php
@@ -2,9 +2,8 @@
 
 namespace Drupal\purl\Plugin;
 
-use Drupal\Component\Plugin\Factory\DefaultFactory;
-use Drupal\purl\Plugin\Purl\Provider\ConfigurableInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\purl\Plugin\Purl\Provider\ProviderInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;


### PR DESCRIPTION
Other small cleanup items -- plugin annotation that I tried when trying to generate plugin instances, may or may not be important, and a fix for a conflict with the core Webprofiler module.

The module in general needs a cleanup from coder/phpcbf, as there are lots of code style warnings, but can do this after this set of PRs are merged, as the cleanup will affect just about every file.