### PR TITLE
Set group context on all rewritten URLs, not just those in the group

### DIFF
--- a/src/PathProcessor/PurlContextOutboundPathProcessor.php
+++ b/src/PathProcessor/PurlContextOutboundPathProcessor.php
@@ -28,13 +28,13 @@ class PurlContextOutboundPathProcessor implements OutboundPathProcessorInterface
 
     public function processOutbound($path, &$options = array(), Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL)
     {
-        if (array_key_exists('purl_context', $options) && $options['purl_context'] == false) {
+      if (count($this->matchedModifiers->getMatched()) && $bubbleable_metadata) {
+        $cacheContexts = $bubbleable_metadata->getCacheContexts();
+        $cacheContexts[] = 'purl';
+        $bubbleable_metadata->setCacheContexts($cacheContexts);
+      }
 
-            if (count($this->matchedModifiers->getMatched()) && $bubbleable_metadata) {
-                $cacheContexts = $bubbleable_metadata->getCacheContexts();
-                $cacheContexts[] = 'purl';
-                $bubbleable_metadata->setCacheContexts($cacheContexts);
-            }
+        if (array_key_exists('purl_context', $options) && $options['purl_context'] == false) {
 
             return $this->contextHelper->processOutbound(
               $this->matchedModifiers->createContexts(Context::EXIT_CONTEXT),


### PR DESCRIPTION
The outbound URL rewriting adds the group path to each URL. However, it does not set a cache context for these rewritten links -- so if you go to a different Purl context, you get cached links from the first context that generated the links, until you clear the cache.

CacheContext was already set correctly for links within a group, just not for the other rewritten links.

This PR adds a cache context to all URLs generated on a page, if there's an active Purl context.