### PR TITLE
Various patches

### DIFF
--- a/purl.install
+++ b/purl.install
@@ -1,58 +1,69 @@
 <?php
 
-function purl_schema()
-{
-    $schema = array();
+/**
+ * Implements hook_schema().
+ */
+function purl_schema() {
+  // Flush all caches to prevent the 'Plugin not found'-exception on install.
+  drupal_flush_all_caches();
 
-    $schema['purl_providers_settings'] = array(
-        'fields' => array(
-            'provider' => array(
-                'type' => 'varchar',
-                'length' => 150,
-                'not null' => true,
-            ),
-            'method' => array(
-                'type' => 'varchar',
-                'length' => 255,
-                'not null' => true,
-            ),
-            'settings' => array(
-                'type' => 'text',
-                'not null' => true,
-                'mysql_type' => 'mediumtext',
-            ),
-            'rebuild' => array(
-                'type' => 'int',
-                //'size' => 'tinyint',
-                'default' => 0,
-            ),
-        ),
-        'primary key' => array('provider'),
-        'description' => 'PURL provider settings',
+  $schema['purl_providers_settings'] = array(
+    'fields' => array(
+      'provider' => array(
+        'description' => '',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ),
+      'method' => array(
+        'description' => '',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ),
+      'settings' => array(
+        'description' => '',
+        'type' => 'text',
+        'not null' => TRUE,
+        'size' => 'medium',
+      ),
+      'rebuild' => array(
+        'description' => '',
+        'type' => 'int',
+        'size' => 'tiny',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+    ),
+    'primary key' => array(array('provider', 191)),
+    'description' => 'PURL provider settings',
     );
 
-    $schema['purl_modifiers'] = array(
-        'fields' => array(
-            'provider' => array(
-                'type' => 'varchar',
-                'length' => 150,
-                'not null' => true,
-            ),
-            'modifier' => array(
-                'type' => 'varchar',
-                'length' => 150,
-                'not null' => true,
-            ),
-            'value' => array(
-                'type' => 'text',
-                'not null' => true,
-                'mysql_type' => 'mediumtext',
-            ),
-        ),
-        'primary key' => array('provider', 'modifier'),
-        'description' => 'Index of PURL modifiers',
-    );
+  $schema['purl_modifiers'] = array(
+    'fields' => array(
+      'provider' => array(
+        'description' => '',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ),
+      'modifier' => array(
+        'description' => '',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ),
+      'value' => array(
+        'description' => '',
+        'type' => 'text',
+        'not null' => TRUE,
+        'mysql_type' => 'mediumtext',
+      ),
+    ),
+    'primary key' => array(array('provider', 191), array('modifier', 191)),
+    'description' => 'Index of PURL modifiers',
+  );
 
-    return $schema;
+  return $schema;
 }
 

--- a/purl.module
+++ b/purl.module
@@ -8,49 +8,6 @@ use Drupal\purl\Entity\Provider;
 use Drupal\node\NodeTypeInterface;
 use Drupal\Core\Form;
 
-function purl_entity_base_field_info(EntityTypeInterface $entity_type) {
-
-  if ($entity_type->id() !== 'menu_link_content') {
-    return;
-  }
-
-  $fields = [];
-
-  /* @todo Remove this; we don't need these extra fields anymore */
-
-  $fields['purl_provider'] = BaseFieldDefinition::create('entity_reference')
-    ->setLabel(t('PURL provider'))
-    ->setName('purl_provider')
-    ->setRevisionable(false)
-    ->setTranslatable(false)
-    ->setDescription('PURL provider')
-    ->setSettings([
-      'target_type' => 'purl_provider',
-      'default_value' => null,
-    ]);
-
-  $fields['purl_modifier'] = BaseFieldDefinition::create('string')
-    ->setLabel(t('PURL modifier'))
-    ->setName('purl_modifier')
-    ->setRevisionable(false)
-    ->setDescription('PURL modififer')
-    ->setSettings([
-      'default_value' => null,
-      'max_length' => 255,
-    ]);
-
-  $fields['purl_strip_context'] = BaseFieldDefinition::create('boolean')
-    ->setLabel(t('PURL strip context'))
-    ->setName('purl_strip_context')
-    ->setRevisionable(false)
-    ->setDescription('PURL strip context')
-    ->setSettings([
-      'default_value' => false,
-    ]);
-
-  return $fields;
-}
-
 function purl_form_menu_edit_form_alter(&$form, $form_state) {
   $providers = Provider::loadMultiple();
 

--- a/purl.services.yml
+++ b/purl.services.yml
@@ -17,7 +17,7 @@ services:
 
   purl.request_subscriber:
     class: Drupal\purl\Event\RequestSubscriber
-    arguments: 
+    arguments:
       - '@purl.modifier_index'
       - '@purl.matched_modifiers'
     tags:
@@ -29,11 +29,6 @@ services:
     tags:
       - { name: event_subscriber }
 
-  purl.provider_storage:
-    class: Drupal\Core\Entity\EntityStorageInterface
-    factory: ['@entity.manager', getStorage]
-    arguments: ['purl_provider']
-
   cache_context.purl:
     class: Drupal\purl\Cache\Context\PurlCacheContext
     tags:
@@ -42,14 +37,14 @@ services:
 
   purl.rebuild_index:
     class: Drupal\purl\Event\RebuildIndex
-    arguments: 
+    arguments:
       - '@purl.modifier_index'
     tags:
       - { name: event_subscriber }
 
   purl.outbound_path_processor:
     class: Drupal\purl\PathProcessor\PurlContextOutboundPathProcessor
-    arguments: 
+    arguments:
       - '@purl.matched_modifiers'
       - '@purl.context_helper'
     tags:
@@ -78,4 +73,4 @@ services:
 
   purl.context_helper:
     class: Drupal\purl\ContextHelper
-    arguments: ['@purl.provider_storage']
+    arguments: ['@entity_type.manager']

--- a/src/Annotation/PurlMethod.php
+++ b/src/Annotation/PurlMethod.php
@@ -20,7 +20,7 @@ class PurlMethod extends Plugin
         }
 
         if (!isset($this->definition['stages'])) {
-          $this->definition['stage'] = [MethodInterface::STAGE_PROCESS_OUTBOUND];
+          $this->definition['stages'] = [MethodInterface::STAGE_PROCESS_OUTBOUND];
         }
     }
 }

--- a/src/ContextHelper.php
+++ b/src/ContextHelper.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\purl;
 
-use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\purl\Entity\Provider;
 use Drupal\purl\Plugin\Purl\Method\MethodInterface;
@@ -12,13 +12,18 @@ class ContextHelper
 {
 
   /**
-   * @var EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManager
    */
-  protected $storage;
+  protected $entityTypeManager;
 
-  public function __construct(EntityStorageInterface $storage)
+  /**
+   * ContextHelper constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   */
+  public function __construct(EntityTypeManager $entity_type_manager)
   {
-    $this->storage = $storage;
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -105,7 +110,7 @@ class ContextHelper
       return [];
     }
 
-    $providers = $this->storage->loadMultiple(array_keys($map));
+    $providers = $this->entityTypeManager->getStorage('purl_provider')->loadMultiple(array_keys($map));
 
     return array_map(function (Provider $provider) use ($map) {
       return new Context($map[$provider->id()], $provider->getMethodPlugin());

--- a/src/Controller/ModifiersController.php
+++ b/src/Controller/ModifiersController.php
@@ -45,9 +45,6 @@ class ModifiersController extends BaseController
   {
     $build = array();
 
-    $ids = \Drupal::entityQuery('purl_provider')
-      ->execute();
-
     $headers = array('provider', 'modifier', 'value');
 
     $headers = array_map(function ($header) {
@@ -56,9 +53,9 @@ class ModifiersController extends BaseController
 
     $rows = array();
 
-    foreach ($this->modifierIndex->findModifiers() as $modifier) {
+    foreach ($this->modifierIndex->findAll() as $modifier) {
 
-      $provider = $modifier['provider'];
+      $provider = $modifier->getProvider();
 
       if (!$provider) {
         continue;
@@ -67,14 +64,14 @@ class ModifiersController extends BaseController
       $row = array();
 
       $row[] = array(
-        'data' => $provider->getLabel()
+        'data' => $provider->getLabel(),
       );
 
       $row[] = array(
         'data' => array(
           '#type' => 'html_tag',
           '#tag' => 'code',
-          '#value' => $modifier['modifier'],
+          '#value' => $modifier->getModifierKey(),
         ),
       );
 
@@ -82,13 +79,12 @@ class ModifiersController extends BaseController
         'data' => array(
           '#type' => 'html_tag',
           '#tag' => 'code',
-          '#value' => $this->stringify($modifier['value']),
+          '#value' => $this->stringify($modifier->getValue()),
         ),
       );
 
       $rows[] = $row;
     }
-
 
     $build['modifiers'] = array(
       '#theme' => 'table',

--- a/src/Event/RequestSubscriber.php
+++ b/src/Event/RequestSubscriber.php
@@ -61,6 +61,7 @@ class RequestSubscriber implements EventSubscriberInterface
   {
     $request = $event->getRequest();
     $modifiers = $this->getModifiers();
+    $original_uri = $request->getRequestUri();
 
     $matches = array();
 
@@ -104,6 +105,7 @@ class RequestSubscriber implements EventSubscriberInterface
     }
 
     $request->attributes->set('purl.matched_modifiers', $matches);
+    $request->attributes->set('original_uri', $original_uri);
   }
 
   /**

--- a/src/Event/RouteNormalizerRequestSubscriber.php
+++ b/src/Event/RouteNormalizerRequestSubscriber.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\purl\Event;
+
+use Drupal\Core\Routing\RequestHelper;
+use Drupal\redirect\EventSubscriber\RouteNormalizerRequestSubscriber as RedirectRouteNormalizerRequestSubscriber;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+
+/**
+ * Normalizes GET requests performing a redirect if required.
+ *
+ * The normalization can be disabled by setting the "_disable_route_normalizer"
+ * request parameter to TRUE. However, this should be done before
+ * onKernelRequestRedirect() method is executed.
+ *
+ * Override RedirectRouteNormalizerRequestSubscriber to compare the original
+ * uri instead of the request uri that has been altered.
+ */
+class RouteNormalizerRequestSubscriber extends RedirectRouteNormalizerRequestSubscriber {
+
+  /**
+   * Performs a redirect if the URL changes in routing.
+   *
+   * The redirect happens if a URL constructed from the current route is
+   * different from the requested one. Examples:
+   * - Language negotiation system detected a language to use, and that language
+   *   has a path prefix: perform a redirect to the language prefixed URL.
+   * - A route that's set as the front page is requested: redirect to the front
+   *   page.
+   * - Requested path has an alias: redirect to alias.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   *   The Event to process.
+   */
+  public function onKernelRequestRedirect(GetResponseEvent $event) {
+
+    if (!$this->config->get('route_normalizer_enabled') || !$event->isMasterRequest()) {
+      return;
+    }
+
+    $request = $event->getRequest();
+    if ($request->attributes->get('_disable_route_normalizer')) {
+      return;
+    }
+
+    if ($this->redirectChecker->canRedirect($request)) {
+      // The "<current>" placeholder can be used for all routes except the front
+      // page because it's not a real route.
+      $route_name = $this->pathMatcher->isFrontPage() ? '<front>' : '<current>';
+
+      // Don't pass in the query here using $request->query->all()
+      // since that can potentially modify the query parameters.
+      $options = ['absolute' => TRUE];
+      $redirect_uri = $this->urlGenerator->generateFromRoute($route_name, [], $options);
+
+      // Strip off query parameters added by the route such as a CSRF token.
+      if (strpos($redirect_uri, '?') !== FALSE) {
+        $redirect_uri  = strtok($redirect_uri, '?');
+      }
+
+      // Append back the request query string from $_SERVER.
+      $query_string = $request->server->get('QUERY_STRING');
+      if ($query_string) {
+        $redirect_uri .= '?' . $query_string;
+      }
+
+      // Remove /index.php from redirect uri the hard way.
+      if (!RequestHelper::isCleanUrl($request)) {
+        // This needs to be fixed differently.
+        $redirect_uri = str_replace('/index.php', '', $redirect_uri);
+      }
+
+      $uri = $request->attributes->has('original_uri') ? $request->attributes->get('original_uri') : $request->getRequestUri();
+      $original_uri = $request->getSchemeAndHttpHost() . $uri;
+      $original_uri = urldecode($original_uri);
+      $redirect_uri = urldecode($redirect_uri);
+      if ($redirect_uri != $original_uri) {
+        $response = new TrustedRedirectResponse($redirect_uri, $this->config->get('default_status_code'));
+        $response->headers->set('X-Drupal-Route-Normalizer', 1);
+        $event->setResponse($response);
+        // Disable page cache for redirects as that results in unpredictable
+        // behavior, e.g. when a trailing ? without query parameters is
+        // involved.
+        // @todo Remove when https://www.drupal.org/node/2761639 is fixed in
+        //   Drupal core.
+        \Drupal::service('page_cache_kill_switch')->trigger();
+      }
+    }
+  }
+
+}

--- a/src/Plugin/Purl/Provider/StaticProvider.php
+++ b/src/Plugin/Purl/Provider/StaticProvider.php
@@ -12,7 +12,7 @@ use Drupal\purl\Annotation\PurlProvider;
  */
 class StaticProvider extends ProviderAbstract
 {
-    public function getModifiers()
+    public function getModifierData()
     {
         return array(
             'un' => 1,

--- a/src/PurlServiceProvider.php
+++ b/src/PurlServiceProvider.php
@@ -13,6 +13,8 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\DependencyInjection\ServiceProviderBase;
 use Drupal\purl\Routing\PurlRouteProvider;
 use Drupal\purl\Utility\PurlAwareUnroutedUrlAssembler;
+use Drupal\purl\StackMiddleware\PageCache;
+use Drupal\purl\Event\RouteNormalizerRequestSubscriber;
 use Symfony\Component\DependencyInjection\Reference;
 
 class PurlServiceProvider extends ServiceProviderBase
@@ -21,6 +23,11 @@ class PurlServiceProvider extends ServiceProviderBase
   {
     $urlGeneratorDefinition = $container->getDefinition('url_generator');
     $urlGeneratorDefinition->replaceArgument(0, new Reference('purl.url_generator'));
+
+    if ($container->hasDefinition('redirect.route_normalizer_request_subscriber')) {
+      $routeNormalizerDefinition = $container->getDefinition('redirect.route_normalizer_request_subscriber');
+      $routeNormalizerDefinition->setClass(RouteNormalizerRequestSubscriber::class);
+    }
 
     $assemblerDefinition = $container->getDefinition('unrouted_url_assembler');
     $assemblerDefinition->setClass(PurlAwareUnroutedUrlAssembler::class);
@@ -31,5 +38,10 @@ class PurlServiceProvider extends ServiceProviderBase
     $routerDefinition->setClass(PurlRouteProvider::class);
     $routerDefinition->addArgument(new Reference('purl.context_helper'));
     $routerDefinition->addArgument(new Reference('purl.matched_modifiers'));
+
+    if ($container->hasDefinition('http_middleware.page_cache')) {
+      $pageCacheDefinition = $container->getDefinition('http_middleware.page_cache');
+      $pageCacheDefinition->setClass(PageCache::class);
+    }
   }
 }

--- a/src/StackMiddleware/PageCache.php
+++ b/src/StackMiddleware/PageCache.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\purl\StackMiddleware;
+
+use Drupal\page_cache\StackMiddleware\PageCache as CorePageCache;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Executes the page caching before the main kernel takes over the request.
+ */
+class PageCache extends CorePageCache {
+
+  /**
+   * {@inheritdoc}
+   *
+   * Purl removes the path prefixes and then re-initializes the request. As a
+   * result the uri is the same for all requests with a context. By using the
+   * original uri, page cache creates an entry per context instead.
+   */
+  protected function getCacheId(Request $request) {
+    $uri = $request->attributes->has('original_uri') ? $request->attributes->get('original_uri') : $request->getRequestUri();
+    $cid_parts = [
+      $request->getSchemeAndHttpHost() . $uri,
+      $request->getRequestFormat(),
+    ];
+    return implode(':', $cid_parts);
+  }
+
+}


### PR DESCRIPTION
                "Error on clean install - service needs config entity purl_provider before it is available": "patches/purl/purl-d8-install-purl.patch",
                "Error on install - PDOException for key length with InnoDB (updated for github d8 version), reset static cache": "patches/purl/purl-d8-install-innodb.patch",
                "Code consistency/bug fixes": "patches/purl/purl-d8-consistency-fixes.patch",
                "Do not cache url without routes": "patches/purl/purl-d8-do_not_cache_empty_routes.patch",
                "Fix compatibility with Drupal core Internal Page Cache and Redirect": "patches/purl/purl-d8-page-cache-redirect-compatibility-1.patch",
                "Fix compatibility with Drupal 8.5.": "patches/purl/purl-d8-drupal-8.5-compatibility.patch"

Note: there is still an url-generator-host-option.patch in the root of the module, but is that still useful? Doesn't seem to be applied.